### PR TITLE
去掉私有属性名前缀限制

### DIFF
--- a/phpcs/ruleset.xml
+++ b/phpcs/ruleset.xml
@@ -6,6 +6,9 @@
         <exclude name="PEAR.ControlStructures.ControlSignature"/>
         <exclude name="Zend.NamingConventions.ValidVariableName"/>
     </rule>
+    <rule ref="phpcs.NamingConventions.ValidVariableName.PrivateNoUnderscore">
+        <severity>0</severity>
+    </rule>
 
     <rule ref="Squiz.WhiteSpace.OperatorSpacing"/>
     <rule ref="Squiz.WhiteSpace.SemicolonSpacing"/>


### PR DESCRIPTION
psr2规范不建议在私有属性名前加下划线